### PR TITLE
Ce qui me dérange à chaque fois que j'utlise ce kata en formation

### DIFF
--- a/bounded-contexts/java/src/main/java/p1/myshop/api/ShippingWeightController.java
+++ b/bounded-contexts/java/src/main/java/p1/myshop/api/ShippingWeightController.java
@@ -1,7 +1,7 @@
 package p1.myshop.api;
 
 import p1.myshop.services.shipping.DeliveryService;
-import p1.myshop.services.shoppingcart.Cart;
+import p1.myshop.entities.Cart;
 
 // @RestController 
 public class ShippingWeightController {

--- a/bounded-contexts/java/src/main/java/p1/myshop/entities/Cart.java
+++ b/bounded-contexts/java/src/main/java/p1/myshop/entities/Cart.java
@@ -1,4 +1,4 @@
-package p1.myshop.services.shoppingcart;
+package p1.myshop.entities;
 
 import java.util.List;
 

--- a/bounded-contexts/java/src/main/java/p1/myshop/entities/CartItem.java
+++ b/bounded-contexts/java/src/main/java/p1/myshop/entities/CartItem.java
@@ -1,7 +1,4 @@
-package p1.myshop.services.shoppingcart;
-
-import p1.myshop.entities.ItemId;
-import p1.myshop.entities.Quantity;
+package p1.myshop.entities;
 
 public class CartItem {
     public final ItemId itemId;

--- a/bounded-contexts/java/src/main/java/p1/myshop/entities/Quantity.java
+++ b/bounded-contexts/java/src/main/java/p1/myshop/entities/Quantity.java
@@ -2,13 +2,13 @@ package p1.myshop.entities;
 
 public class Quantity {
 
-    int value;
+    int quantity;
 
-    Quantity(int value) {
-        this.value = value;
+    Quantity(int quantity) {
+        this.quantity = quantity;
     }
 
-    public int toInt() {
-        return value;
+    public int quantity() {
+        return quantity;
     }
 }

--- a/bounded-contexts/java/src/main/java/p1/myshop/services/shipping/DeliveryService.java
+++ b/bounded-contexts/java/src/main/java/p1/myshop/services/shipping/DeliveryService.java
@@ -1,7 +1,7 @@
 package p1.myshop.services.shipping;
 
 import p1.myshop.services.catalog.CatalogService;
-import p1.myshop.services.shoppingcart.Cart;
+import p1.myshop.entities.Cart;
 
 public class DeliveryService {
     private final CatalogService catalogService;

--- a/bounded-contexts/java/src/main/java/p1/myshop/services/shipping/DeliveryService.java
+++ b/bounded-contexts/java/src/main/java/p1/myshop/services/shipping/DeliveryService.java
@@ -1,9 +1,7 @@
 package p1.myshop.services.shipping;
 
-import p1.myshop.entities.HasWeight;
 import p1.myshop.services.catalog.CatalogService;
 import p1.myshop.services.shoppingcart.Cart;
-import p1.myshop.services.shoppingcart.CartItem;
 
 public class DeliveryService {
     private final CatalogService catalogService;
@@ -14,7 +12,7 @@ public class DeliveryService {
 
     public double calculateOrderWeight(Cart cart) {
         return cart.items().stream()
-                .mapToDouble(cartItem -> cartItem.quantity.toInt() * catalogService.loadItem(cartItem.itemId).weight())
+                .mapToDouble(cartItem -> cartItem.quantity.quantity() * catalogService.loadItem(cartItem.itemId).weight())
                 .sum();
     }
 }

--- a/bounded-contexts/java/src/main/java/p1/myshop/services/shoppingcart/ShoppingCartService.java
+++ b/bounded-contexts/java/src/main/java/p1/myshop/services/shoppingcart/ShoppingCartService.java
@@ -3,6 +3,6 @@ package p1.myshop.services.shoppingcart;
 import p1.myshop.entities.HasWeight;
 import p1.myshop.services.catalog.CatalogService;
 
-public class ShoppingCarService {
+public class ShoppingCartService {
 
 }


### PR DESCRIPTION
### Ce qu'il y a dans la PR
- Correction d'une typo dans le nom de `ShoppingCartService`
- Prise en compte de la quantité dans le calcul du poids d'une commande
- Rapatriement dans `entity` de `Cart` et `CartItem` qui ne devraient pas être dans `service`.

### Questions ouvertes encore
#### Faut-il renommer `Item `en `Product `?
Je bute toujours sur le fait d'utiliser `Item` (_article_) pour nommer par défaut le concept de _produit_ (`Product`). De mon expérience subjective d'e-commerce, _article_ est dans le domaine panier et livraison, _produit_ est dans le domaine catalogue (et a priori comptabilité). Il se trouve que la plupart du temps, le domaine _catalogue_ est upstream au autres domaines, c'est la golden source par défaut pour ce concept _produit_, et du coup dans un modèle ou il n'y aurait qu'un nom je mettrait `Product`.

#### Faut-il renommer `CartItem` en `CartLine` ?
Ça rajoute de la confusion à la compréhension des participants qui n'est peut-être pas nécessaire. Sans ça, il faut que lea formateurice explique rapidement que `CartItem` ne représente pas le produit du panier, au sens catalogue, mais une ligne du panier, soit un produit avec sa quantité.


